### PR TITLE
Fix wait-for-emulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   # Create and start emulator
   - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
   - emulator -avd test -no-skin -no-audio -no-window &
-  - adb wait-for-device
+  - android-wait-for-emulator
   - adb shell input keyevent 82 &
 
 script: ./gradlew connectedAndroidTest


### PR DESCRIPTION
Usage of `android-wait-for-emulator` as recommended by Travis.