### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+org.gradle.caching = true
+org.gradle.daemon = true
 # Project-wide Gradle settings.
 
 # IDE (e.g. Android Studio) users:


### PR DESCRIPTION

[gradle caching](https://docs.gradle.org/current/userguide/build_cache.html). Shared caches can reduce the number of tasks you need to execute by reusing outputs already generated elsewhere. This can significantly decrease build times. We can enable this feature by setting `org.gradle.caching=true`.

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
